### PR TITLE
Get a single TroveManagerTest to pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .DS_Store
 
 node_modules
+.tool-versions
 
 # output of TypeScript transpilation
 /packages/*/dist

--- a/packages/contracts/contracts/BorrowerOperations.sol
+++ b/packages/contracts/contracts/BorrowerOperations.sol
@@ -216,6 +216,8 @@ contract BorrowerOperations is LiquityBase, Ownable, CheckContract, IBorrowerOpe
         vars.arrayIndex = contractsCache.troveManager.addTroveOwnerToArray(msg.sender);
         emit TroveCreated(msg.sender, vars.arrayIndex);
 
+        collateralToken.safeTransferFrom(msg.sender, address(this), _collateralAmount);
+
         // Move the ether to the Active Pool, and mint the LUSDAmount to the borrower
         _activePoolAddColl(contractsCache.activePool, _collateralAmount);
         _withdrawDebt(contractsCache.activePool, contractsCache.lusdToken, msg.sender, _LUSDAmount, vars.netDebt);

--- a/packages/contracts/utils/deploymentHelpers.js
+++ b/packages/contracts/utils/deploymentHelpers.js
@@ -62,13 +62,13 @@ const maxBytes32 = '0x' + 'f'.repeat(64)
 
 class DeploymentHelper {
 
-  static async deployLiquityCore() {
+  static async deployLiquityCore(collateralTokenAddress) {
     const cmdLineArgs = process.argv
     const frameworkPath = cmdLineArgs[1]
     // console.log(`Framework used:  ${frameworkPath}`)
 
     if (frameworkPath.includes("hardhat")) {
-      return this.deployLiquityCoreHardhat()
+      return this.deployLiquityCoreHardhat(collateralTokenAddress)
     } else if (frameworkPath.includes("truffle")) {
       return this.deployLiquityCoreTruffle()
     }
@@ -86,7 +86,7 @@ class DeploymentHelper {
     }
   }
 
-  static async deployLiquityCoreHardhat() {
+  static async deployLiquityCoreHardhat(collateralToken) {
     const priceFeedTestnet = await PriceFeedTestnet.new()
     const sortedTroves = await SortedTroves.new()
     const troveManager = await TroveManager.new()
@@ -103,9 +103,11 @@ class DeploymentHelper {
       stabilityPool.address,
       borrowerOperations.address
     )
-    const collateralToken = await WETHToken.new()
+    if (!collateralToken) {
+      collateralToken = await WETHToken.new()
+      WETHToken.setAsDeployed(collateralToken)
+    }
     LUSDToken.setAsDeployed(lusdToken)
-    WETHToken.setAsDeployed(collateralToken)
     DefaultPool.setAsDeployed(defaultPool)
     PriceFeedTestnet.setAsDeployed(priceFeedTestnet)
     SortedTroves.setAsDeployed(sortedTroves)


### PR DESCRIPTION
This successfully performs a liquidation.

Includes the following changes:

* Perform the safeTransferFrom inside the openTrove function. I didn't
  see the inital transfer of the collateralToken happening anywhere and
  this seemed like a good place.

* Switch from moving ETH to the collateral token in the default pool.
  This also required wiring in the collateralTokenAddress to the default
  pool.

* Optionally using ERC20Mock instead of WETH for the collateralToken as
  it is a little easier to use.

The test set up got a little more complex as it needed to create a
balance for whale and alice and also approve the borrower operations
contract. Once patterns emerge, that can be extracted into a shared
helper.