### PR TITLE
Keep collateral up-to-date in default pool.

### DIFF
--- a/packages/contracts/contracts/ActivePool.sol
+++ b/packages/contracts/contracts/ActivePool.sol
@@ -4,6 +4,7 @@ pragma solidity 0.6.11;
 
 import './Interfaces/IActivePool.sol';
 import './Interfaces/IDefaultPool.sol';
+import './Interfaces/IStabilityPool.sol';
 import "./Dependencies/SafeMath.sol";
 import "./Dependencies/Ownable.sol";
 import "./Dependencies/CheckContract.sol";
@@ -97,6 +98,8 @@ contract ActivePool is Ownable, CheckContract, IActivePool {
 
         if (_account == defaultPoolAddress) {
             IDefaultPool(defaultPoolAddress).addCollateral(_amount);
+        } else if (_account == stabilityPoolAddress) {
+            IStabilityPool(stabilityPoolAddress).addCollateral(_amount);
         }
 
         // console.log("Sending collateral to account:", _account, _amount);

--- a/packages/contracts/contracts/ActivePool.sol
+++ b/packages/contracts/contracts/ActivePool.sol
@@ -3,6 +3,7 @@
 pragma solidity 0.6.11;
 
 import './Interfaces/IActivePool.sol';
+import './Interfaces/IDefaultPool.sol';
 import "./Dependencies/SafeMath.sol";
 import "./Dependencies/Ownable.sol";
 import "./Dependencies/CheckContract.sol";
@@ -93,6 +94,11 @@ contract ActivePool is Ownable, CheckContract, IActivePool {
         // Collateral = Collateral.sub(_amount);
         // emit ActivePoolCollateralUpdated(Collateral); //TODO before was current value, now would be delta value
         emit CollateralSent(_account, _amount);
+
+        if (_account == defaultPoolAddress) {
+            IDefaultPool(defaultPoolAddress).addCollateral(_amount);
+        }
+
         // console.log("Sending collateral to account:", _account, _amount);
         collateralToken.safeTransfer(_account, _amount);
        

--- a/packages/contracts/contracts/CollSurplusPool.sol
+++ b/packages/contracts/contracts/CollSurplusPool.sol
@@ -8,10 +8,12 @@ import "./Dependencies/Ownable.sol";
 import "./Dependencies/CheckContract.sol";
 import "./Dependencies/console.sol";
 import "./Dependencies/IERC20.sol";
+import "./LPRewards/Dependencies/SafeERC20.sol";
 
 
 contract CollSurplusPool is Ownable, CheckContract, ICollSurplusPool {
     using SafeMath for uint256;
+    using SafeERC20 for IERC20;
 
     string constant public NAME = "CollSurplusPool";
 
@@ -94,9 +96,11 @@ contract CollSurplusPool is Ownable, CheckContract, ICollSurplusPool {
         // Collateral = Collateral.sub(claimableColl);
         emit CollateralSent(_account, claimableColl);
 
-require(1 < 0, "claimColl");
-        (bool success, ) = _account.call{ value: claimableColl }("");
-        require(success, "CollSurplusPool: sending ETH failed");
+        collateralToken.safeTransfer(_account, claimableColl);
+
+// require(1 < 0, "claimColl");
+//         (bool success, ) = _account.call{ value: claimableColl }("");
+//         require(success, "CollSurplusPool: sending ETH failed");
     }
 
     // --- 'require' functions ---

--- a/packages/contracts/contracts/DefaultPool.sol
+++ b/packages/contracts/contracts/DefaultPool.sol
@@ -101,8 +101,15 @@ contract DefaultPool is Ownable, CheckContract, IDefaultPool {
 
     function decreaseDebt(uint _amount) external override {
         _requireCallerIsTroveManager();
+
         Debt = Debt.sub(_amount);
         emit DefaultPoolDebtUpdated(Debt);
+    }
+
+    function addCollateral(uint _amount) external override {
+        _requireCallerIsActivePool();
+        Collateral = Collateral.add(_amount);
+        emit DefaultPoolCollateralUpdated(Collateral);
     }
 
     // --- 'require' functions ---

--- a/packages/contracts/contracts/Interfaces/IDefaultPool.sol
+++ b/packages/contracts/contracts/Interfaces/IDefaultPool.sol
@@ -13,4 +13,5 @@ interface IDefaultPool is IPool {
 
     // --- Functions ---
     function sendCollateralToActivePool(uint _amount) external;
+    function addCollateral(uint _amount) external;
 }

--- a/packages/contracts/contracts/Interfaces/IStabilityPool.sol
+++ b/packages/contracts/contracts/Interfaces/IStabilityPool.sol
@@ -190,8 +190,8 @@ interface IStabilityPool {
     function getCompoundedFrontEndStake(address _frontEnd) external view returns (uint);
 
     /*
-     * Fallback function
+     * Adds collateral to the bookkeeping
      * Only callable by Active Pool, it just accounts for ETH received
-     * receive() external payable;
      */
+     function addCollateral(uint _amount) external;
 }

--- a/packages/contracts/contracts/StabilityPool.sol
+++ b/packages/contracts/contracts/StabilityPool.sol
@@ -319,6 +319,12 @@ contract StabilityPool is LiquityBase, Ownable, CheckContract, IStabilityPool {
         return totalLUSDDeposits;
     }
 
+    function addCollateral(uint _amount) external override {
+        _requireCallerIsActivePool();
+        ETH = ETH.add(_amount);
+        StabilityPoolCollateralUpdated(ETH);
+    }
+
     // --- External Depositor Functions ---
 
     /*  provideToSP():
@@ -991,9 +997,9 @@ require(1 < 0, "_sendCollateralGainToDepositor");
 
     // --- Fallback function ---
 
-    receive() external payable {
-        _requireCallerIsActivePool();
-        ETH = ETH.add(msg.value);
-        StabilityPoolCollateralUpdated(ETH);
-    }
+    // receive() external payable {
+    //     _requireCallerIsActivePool();
+    //     ETH = ETH.add(msg.value);
+    //     StabilityPoolCollateralUpdated(ETH);
+    // }
 }

--- a/packages/contracts/contracts/TroveManager.sol
+++ b/packages/contracts/contracts/TroveManager.sol
@@ -1072,7 +1072,6 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
 
             // Transfer from DefaultPool to ActivePool
             _movePendingTroveRewardsToActivePool(_activePool, _defaultPool, pendingLUSDDebtReward, pendingETHReward);
-
             emit TroveUpdated(
                 _borrower,
                 Troves[_borrower].debt,

--- a/packages/contracts/test/TroveManagerTest.js
+++ b/packages/contracts/test/TroveManagerTest.js
@@ -601,7 +601,6 @@ contract('TroveManager', async accounts => {
     assert.isTrue(TCR_5.gte(TCR_4))
   })
 
-  //failing
   it("liquidate(): a pure redistribution reduces the TCR only as a result of compensation", async () => {
     await openTrove({ ICR: toBN(dec(4, 18)), extraParams: { from: whale } })
 
@@ -838,7 +837,6 @@ contract('TroveManager', async accounts => {
     assert.isAtMost(th.getDifference(bob_ETHGain_After, bob_ETHGain_Before.add(th.applyLiquidationFee(B_collateral).mul(bob_Deposit_Before).div(totalDeposits))), 1000000)
   })
 
-  //failing
   it("liquidate(): does not alter the liquidated user's token balance", async () => {
     await openTrove({ ICR: toBN(dec(10, 18)), extraParams: { from: whale } })
     const { lusdAmount: A_lusdAmount } = await openTrove({ ICR: toBN(dec(2, 18)), extraLUSDAmount: toBN(dec(300, 18)), extraParams: { from: alice } })
@@ -881,7 +879,6 @@ contract('TroveManager', async accounts => {
     assert.equal((await lusdToken.balanceOf(carol)).toString(), C_lusdAmount)
   })
 
-  // failing
   it("liquidate(): liquidates based on entire/collateral debt (including pending rewards), not raw collateral/debt", async () => {
     await openTrove({ ICR: toBN(dec(8, 18)), extraLUSDAmount: toBN(dec(100, 18)), extraParams: { from: alice } })
     await openTrove({ ICR: toBN(dec(221, 16)), extraLUSDAmount: toBN(dec(100, 18)), extraParams: { from: bob } })
@@ -1041,7 +1038,6 @@ contract('TroveManager', async accounts => {
   })
 
   // --- liquidateTroves() ---
-  //failing
   it('liquidateTroves(): liquidates a Trove that a) was skipped in a previous liquidation and b) has pending rewards', async () => {
     // A, B, C, D, E open troves
     await openTrove({ ICR: toBN(dec(333, 16)), extraParams: { from: D } })
@@ -1287,7 +1283,6 @@ contract('TroveManager', async accounts => {
     assert.equal(listSize_Before, listSize_After)
   })
 
-  //failing
   it("liquidateTroves(): liquidates based on entire/collateral debt (including pending rewards), not raw collateral/debt", async () => {
     await openTrove({ ICR: toBN(dec(400, 16)), extraParams: { from: alice } })
     await openTrove({ ICR: toBN(dec(221, 16)), extraParams: { from: bob } })
@@ -1605,7 +1600,7 @@ contract('TroveManager', async accounts => {
   })
 
   //failing
-  it("liquidateTroves(): Liquidating troves with SP deposits correctly impacts their SP deposit and ETH gain", async () => {
+  it.only("liquidateTroves(): Liquidating troves with SP deposits correctly impacts their SP deposit and ETH gain", async () => {
     // Whale provides 400 LUSD to the SP
     const whaleDeposit = toBN(dec(40000, 18))
     await openTrove({ ICR: toBN(dec(100, 18)), extraLUSDAmount: whaleDeposit, extraParams: { from: whale } })
@@ -1781,7 +1776,6 @@ contract('TroveManager', async accounts => {
 
 
   // --- batchLiquidateTroves() ---
-  //failing
   it('batchLiquidateTroves(): liquidates a Trove that a) was skipped in a previous liquidation and b) has pending rewards', async () => {
     // A, B, C, D, E open troves 
     await openTrove({ ICR: toBN(dec(300, 16)), extraParams: { from: C } })
@@ -2760,11 +2754,14 @@ contract('TroveManager', async accounts => {
     assert.equal(carol_Status, 1)
   })
 
-  //failing
   it("redeemCollateral(): performs partial redemption if resultant debt is > minimum net debt", async () => {
-    await borrowerOperations.openTrove(th._100pct, await getOpenTroveLUSDAmount(dec(10000, 18)), A, A, { from: A, value: dec(1000, 'ether') })
-    await borrowerOperations.openTrove(th._100pct, await getOpenTroveLUSDAmount(dec(20000, 18)), B, B, { from: B, value: dec(1000, 'ether') })
-    await borrowerOperations.openTrove(th._100pct, await getOpenTroveLUSDAmount(dec(30000, 18)), C, C, { from: C, value: dec(1000, 'ether') })
+    for (let acct of [A, B, C]) {
+      await collateralToken.mint(acct, dec(1000, 18));
+      await collateralToken.approveInternal(acct, borrowerOperations.address, dec(1000, 18));
+    }
+    await borrowerOperations.openTrove(th._100pct, await getOpenTroveLUSDAmount(dec(10000, 18)), A, A, dec(1000, 18), { from: A })
+    await borrowerOperations.openTrove(th._100pct, await getOpenTroveLUSDAmount(dec(20000, 18)), B, B, dec(1000, 18), { from: B })
+    await borrowerOperations.openTrove(th._100pct, await getOpenTroveLUSDAmount(dec(30000, 18)), C, C, dec(1000, 18), { from: C })
 
     // A and C send all their tokens to B
     await lusdToken.transfer(B, await lusdToken.balanceOf(A), {from: A})
@@ -2789,11 +2786,14 @@ contract('TroveManager', async accounts => {
     await th.assertIsApproximatelyEqual(A_debt, dec(4600, 18), 1000) 
   })
 
-  //failing
   it("redeemCollateral(): doesn't perform partial redemption if resultant debt would be < minimum net debt", async () => {
-    await borrowerOperations.openTrove(th._100pct, await getOpenTroveLUSDAmount(dec(6000, 18)), A, A, { from: A, value: dec(1000, 'ether') })
-    await borrowerOperations.openTrove(th._100pct, await getOpenTroveLUSDAmount(dec(20000, 18)), B, B, { from: B, value: dec(1000, 'ether') })
-    await borrowerOperations.openTrove(th._100pct, await getOpenTroveLUSDAmount(dec(30000, 18)), C, C, { from: C, value: dec(1000, 'ether') })
+    for (let acct of [A, B, C]) {
+      await collateralToken.mint(acct, dec(1000, 18));
+      await collateralToken.approveInternal(acct, borrowerOperations.address, dec(1000, 18));
+    }
+    await borrowerOperations.openTrove(th._100pct, await getOpenTroveLUSDAmount(dec(6000, 18)), A, A, dec(1000, 18), { from: A })
+    await borrowerOperations.openTrove(th._100pct, await getOpenTroveLUSDAmount(dec(20000, 18)), B, B, dec(1000, 18), { from: B })
+    await borrowerOperations.openTrove(th._100pct, await getOpenTroveLUSDAmount(dec(30000, 18)), C, C, dec(1000, 18), { from: C })
 
     // A and C send all their tokens to B
     await lusdToken.transfer(B, await lusdToken.balanceOf(A), {from: A})
@@ -3216,7 +3216,6 @@ contract('TroveManager', async accounts => {
     assert.isTrue(tx5.receipt.status)
   })
 
-  //failing
   it("redeemCollateral(): doesn't affect the Stability Pool deposits or ETH gain of redeemed-from troves", async () => {
     await openTrove({ ICR: toBN(dec(20, 18)), extraParams: { from: whale } })
 
@@ -3837,7 +3836,6 @@ contract('TroveManager', async accounts => {
     assert.isTrue(lastFeeOpTime_3.gt(lastFeeOpTime_1))
   })
 
-  //failing
   it("redeemCollateral(): a redemption made at zero base rate send a non-zero ETHFee to LQTY staking contract", async () => {
     // time fast-forwards 1 year, and multisig stakes 1 LQTY
     await th.fastForwardTime(timeValues.SECONDS_IN_ONE_YEAR, web3.currentProvider)
@@ -3870,7 +3868,7 @@ contract('TroveManager', async accounts => {
     assert.isTrue(baseRate_1.gt(toBN('0')))
 
     // Check LQTY Staking contract balance after is non-zero
-    const lqtyStakingBalance_After = toBN(await web3.eth.getBalance(lqtyStaking.address))
+    const lqtyStakingBalance_After = toBN(await collateralToken.balanceOf(lqtyStaking.address))
     assert.isTrue(lqtyStakingBalance_After.gt(toBN('0')))
   })
 
@@ -3910,7 +3908,6 @@ contract('TroveManager', async accounts => {
     assert.isTrue(F_ETH_After.gt('0'))
   })
 
-  //failing
   it("redeemCollateral(): a redemption made at a non-zero base rate send a non-zero ETHFee to LQTY staking contract", async () => {
     // time fast-forwards 1 year, and multisig stakes 1 LQTY
     await th.fastForwardTime(timeValues.SECONDS_IN_ONE_YEAR, web3.currentProvider)
@@ -3939,7 +3936,7 @@ contract('TroveManager', async accounts => {
     const baseRate_1 = await troveManager.baseRate()
     assert.isTrue(baseRate_1.gt(toBN('0')))
 
-    const lqtyStakingBalance_Before = toBN(await web3.eth.getBalance(lqtyStaking.address))
+    const lqtyStakingBalance_Before = toBN(await collateralToken.balanceOf(lqtyStaking.address))
 
     // B redeems 10 LUSD
     await th.redeemCollateral(B, contracts, dec(10, 18))
@@ -3947,7 +3944,7 @@ contract('TroveManager', async accounts => {
     // Check B's balance has decreased by 10 LUSD
     assert.equal(await lusdToken.balanceOf(B), B_balanceBefore.sub(toBN(dec(10, 18))).toString())
 
-    const lqtyStakingBalance_After = toBN(await web3.eth.getBalance(lqtyStaking.address))
+    const lqtyStakingBalance_After = toBN(await collateralToken.balanceOf(lqtyStaking.address))
 
     // check LQTY Staking balance has increased
     assert.isTrue(lqtyStakingBalance_After.gt(lqtyStakingBalance_Before))
@@ -3996,7 +3993,6 @@ contract('TroveManager', async accounts => {
     assert.isTrue(F_ETH_After.gt(F_ETH_Before))
   })
 
-  //failing
   it("redeemCollateral(): a redemption sends the ETH remainder (ETHDrawn - ETHFee) to the redeemer", async () => {
     // time fast-forwards 1 year, and multisig stakes 1 LQTY
     await th.fastForwardTime(timeValues.SECONDS_IN_ONE_YEAR, web3.currentProvider)
@@ -4010,7 +4006,7 @@ contract('TroveManager', async accounts => {
     const { totalDebt: C_totalDebt } = await openTrove({ ICR: toBN(dec(180, 16)), extraLUSDAmount: dec(100, 18), extraParams: { from: C } })
     const totalDebt = W_totalDebt.add(A_totalDebt).add(B_totalDebt).add(C_totalDebt)
 
-    const A_balanceBefore = toBN(await web3.eth.getBalance(A))
+    const A_balanceBefore = toBN(await collateralToken.balanceOf(A))
 
     // Confirm baseRate before redemption is 0
     const baseRate = await troveManager.baseRate()
@@ -4034,7 +4030,7 @@ contract('TroveManager', async accounts => {
     ETHRemainder = 0.045 - 0.001003... = 0.0439961538462
     */
 
-    const A_balanceAfter = toBN(await web3.eth.getBalance(A))
+    const A_balanceAfter = toBN(await collateralToken.balanceOf(A))
 
     // check A's ETH balance has increased by 0.045 ETH 
     const price = await priceFeed.getPrice()
@@ -4093,10 +4089,10 @@ contract('TroveManager', async accounts => {
     const { netDebt: D_netDebt } = await openTrove({ ICR: toBN(dec(280, 16)), extraLUSDAmount: dec(100, 18), extraParams: { from: D } })
     const redemptionAmount = A_netDebt.add(B_netDebt).add(C_netDebt).add(toBN(dec(10, 18)))
 
-    const A_balanceBefore = toBN(await web3.eth.getBalance(A))
-    const B_balanceBefore = toBN(await web3.eth.getBalance(B))
-    const C_balanceBefore = toBN(await web3.eth.getBalance(C))
-    const D_balanceBefore = toBN(await web3.eth.getBalance(D))
+    const A_balanceBefore = toBN(await collateralToken.balanceOf(A))
+    const B_balanceBefore = toBN(await collateralToken.balanceOf(B))
+    const C_balanceBefore = toBN(await collateralToken.balanceOf(C))
+    const D_balanceBefore = toBN(await collateralToken.balanceOf(D))
 
     const A_collBefore = await troveManager.getTroveColl(A)
     const B_collBefore = await troveManager.getTroveColl(B)
@@ -4126,10 +4122,10 @@ contract('TroveManager', async accounts => {
     ETHDrawn from C = 130/200 = 0.65 ETH --> Surplus = (2-0.65) = 1.35
     */
 
-    const A_balanceAfter = toBN(await web3.eth.getBalance(A))
-    const B_balanceAfter = toBN(await web3.eth.getBalance(B))
-    const C_balanceAfter = toBN(await web3.eth.getBalance(C))
-    const D_balanceAfter = toBN(await web3.eth.getBalance(D))
+    const A_balanceAfter = toBN(await collateralToken.balanceOf(A))
+    const B_balanceAfter = toBN(await collateralToken.balanceOf(B))
+    const C_balanceAfter = toBN(await collateralToken.balanceOf(C))
+    const D_balanceAfter = toBN(await collateralToken.balanceOf(D))
 
     // Check A, B, C’s trove collateral balance is zero (fully redeemed-from troves)
     const A_collAfter = await troveManager.getTroveColl(A)
@@ -4150,7 +4146,9 @@ contract('TroveManager', async accounts => {
     assert.isTrue(D_balanceAfter.eq(D_balanceBefore))
 
     // D is not closed, so cannot open trove
-    await assertRevert(borrowerOperations.openTrove(th._100pct, 0, ZERO_ADDRESS, ZERO_ADDRESS, { from: D, value: dec(10, 18) }), 'BorrowerOps: Trove is active')
+    console.log("before revert");
+    await assertRevert(borrowerOperations.openTrove(th._100pct, 0, ZERO_ADDRESS, ZERO_ADDRESS, dec(10, 18), { from: D }), 'BorrowerOps: Trove is active')
+    console.log("after revert");
 
     return {
       A_netDebt, A_coll,
@@ -4214,9 +4212,9 @@ contract('TroveManager', async accounts => {
       C_netDebt, C_coll,
     } = await redeemCollateral3Full1Partial()
 
-    const A_balanceBefore = toBN(await web3.eth.getBalance(A))
-    const B_balanceBefore = toBN(await web3.eth.getBalance(B))
-    const C_balanceBefore = toBN(await web3.eth.getBalance(C))
+    const A_balanceBefore = toBN(await collateralToken.balanceOf(A))
+    const B_balanceBefore = toBN(await collateralToken.balanceOf(B))
+    const C_balanceBefore = toBN(await collateralToken.balanceOf(C))
 
     // CollSurplusPool endpoint cannot be called directly
     await assertRevert(collSurplusPool.claimColl(A), 'CollSurplusPool: Caller is not Borrower Operations')
@@ -4225,9 +4223,9 @@ contract('TroveManager', async accounts => {
     await borrowerOperations.claimCollateral({ from: B, gasPrice: 0 })
     await borrowerOperations.claimCollateral({ from: C, gasPrice: 0 })
 
-    const A_balanceAfter = toBN(await web3.eth.getBalance(A))
-    const B_balanceAfter = toBN(await web3.eth.getBalance(B))
-    const C_balanceAfter = toBN(await web3.eth.getBalance(C))
+    const A_balanceAfter = toBN(await collateralToken.balanceOf(A))
+    const B_balanceAfter = toBN(await collateralToken.balanceOf(B))
+    const C_balanceAfter = toBN(await collateralToken.balanceOf(C))
 
     const price = await priceFeed.getPrice()
 
@@ -4237,7 +4235,7 @@ contract('TroveManager', async accounts => {
   })
 
   //failing
-  it("redeemCollateral(): a redemption that closes a trove leaves the trove's ETH surplus (collateral - ETH drawn) available for the trove owner after re-opening trove", async () => {
+  it.only("redeemCollateral(): a redemption that closes a trove leaves the trove's ETH surplus (collateral - ETH drawn) available for the trove owner after re-opening trove", async () => {
     const {
       A_netDebt, A_coll: A_collBefore,
       B_netDebt, B_coll: B_collBefore,

--- a/packages/contracts/test/TroveManagerTest.js
+++ b/packages/contracts/test/TroveManagerTest.js
@@ -1599,8 +1599,7 @@ contract('TroveManager', async accounts => {
     assert.isTrue(TCR_After.gte(TCR_Before.mul(toBN(995)).div(toBN(1000))))
   })
 
-  //failing
-  it.only("liquidateTroves(): Liquidating troves with SP deposits correctly impacts their SP deposit and ETH gain", async () => {
+  it("liquidateTroves(): Liquidating troves with SP deposits correctly impacts their SP deposit and ETH gain", async () => {
     // Whale provides 400 LUSD to the SP
     const whaleDeposit = toBN(dec(40000, 18))
     await openTrove({ ICR: toBN(dec(100, 18)), extraLUSDAmount: whaleDeposit, extraParams: { from: whale } })
@@ -2322,7 +2321,6 @@ contract('TroveManager', async accounts => {
     assert.equal(partialRedemptionHintNICR, '0')
   });
 
-  //failing
   it('redeemCollateral(): cancels the provided LUSD with debt from Troves with the lowest ICRs and sends an equivalent amount of Ether', async () => {
     // --- SETUP ---
     const { totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(310, 16)), extraLUSDAmount: dec(10, 18), extraParams: { from: alice } })
@@ -2333,7 +2331,7 @@ contract('TroveManager', async accounts => {
     // start Dennis with a high ICR
     await openTrove({ ICR: toBN(dec(100, 18)), extraLUSDAmount: redemptionAmount, extraParams: { from: dennis } })
 
-    const dennis_ETHBalance_Before = toBN(await web3.eth.getBalance(dennis))
+    const dennis_ETHBalance_Before = toBN(await collateralToken.balanceOf(dennis))
 
     const dennis_LUSDBalance_Before = await lusdToken.balanceOf(dennis)
 
@@ -2370,7 +2368,6 @@ contract('TroveManager', async accounts => {
       0, th._100pct,
       {
         from: dennis,
-        gasPrice: 0
       }
     )
 
@@ -2391,7 +2388,7 @@ contract('TroveManager', async accounts => {
     assert.equal(bob_debt_After, '0')
     assert.equal(carol_debt_After, '0')
 
-    const dennis_ETHBalance_After = toBN(await web3.eth.getBalance(dennis))
+    const dennis_ETHBalance_After = toBN(await collateralToken.balanceOf(dennis))
     const receivedETH = dennis_ETHBalance_After.sub(dennis_ETHBalance_Before)
 
     const expectedTotalETHDrawn = redemptionAmount.div(toBN(200)) // convert redemptionAmount LUSD to ETH, at ETH:USD price 200
@@ -2403,7 +2400,6 @@ contract('TroveManager', async accounts => {
     assert.equal(dennis_LUSDBalance_After, dennis_LUSDBalance_Before.sub(redemptionAmount))
   })
 
-  //failing
   it('redeemCollateral(): with invalid first hint, zero address', async () => {
     // --- SETUP ---
     const { totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(310, 16)), extraLUSDAmount: dec(10, 18), extraParams: { from: alice } })
@@ -2414,7 +2410,7 @@ contract('TroveManager', async accounts => {
     // start Dennis with a high ICR
     await openTrove({ ICR: toBN(dec(100, 18)), extraLUSDAmount: redemptionAmount, extraParams: { from: dennis } })
 
-    const dennis_ETHBalance_Before = toBN(await web3.eth.getBalance(dennis))
+    const dennis_ETHBalance_Before = toBN(await collateralToken.balanceOf(dennis))
 
     const dennis_LUSDBalance_Before = await lusdToken.balanceOf(dennis)
 
@@ -2451,7 +2447,6 @@ contract('TroveManager', async accounts => {
       0, th._100pct,
       {
         from: dennis,
-        gasPrice: 0
       }
     )
 
@@ -2472,7 +2467,7 @@ contract('TroveManager', async accounts => {
     assert.equal(bob_debt_After, '0')
     assert.equal(carol_debt_After, '0')
 
-    const dennis_ETHBalance_After = toBN(await web3.eth.getBalance(dennis))
+    const dennis_ETHBalance_After = toBN(await collateralToken.balanceOf(dennis))
     const receivedETH = dennis_ETHBalance_After.sub(dennis_ETHBalance_Before)
 
     const expectedTotalETHDrawn = redemptionAmount.div(toBN(200)) // convert redemptionAmount LUSD to ETH, at ETH:USD price 200
@@ -2484,7 +2479,6 @@ contract('TroveManager', async accounts => {
     assert.equal(dennis_LUSDBalance_After, dennis_LUSDBalance_Before.sub(redemptionAmount))
   })
 
-  //failing
   it('redeemCollateral(): with invalid first hint, non-existent trove', async () => {
     // --- SETUP ---
     const { totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(310, 16)), extraLUSDAmount: dec(10, 18), extraParams: { from: alice } })
@@ -2495,7 +2489,7 @@ contract('TroveManager', async accounts => {
     // start Dennis with a high ICR
     await openTrove({ ICR: toBN(dec(100, 18)), extraLUSDAmount: redemptionAmount, extraParams: { from: dennis } })
 
-    const dennis_ETHBalance_Before = toBN(await web3.eth.getBalance(dennis))
+    const dennis_ETHBalance_Before = toBN(await collateralToken.balanceOf(dennis))
 
     const dennis_LUSDBalance_Before = await lusdToken.balanceOf(dennis)
 
@@ -2532,7 +2526,6 @@ contract('TroveManager', async accounts => {
       0, th._100pct,
       {
         from: dennis,
-        gasPrice: 0
       }
     )
 
@@ -2553,7 +2546,7 @@ contract('TroveManager', async accounts => {
     assert.equal(bob_debt_After, '0')
     assert.equal(carol_debt_After, '0')
 
-    const dennis_ETHBalance_After = toBN(await web3.eth.getBalance(dennis))
+    const dennis_ETHBalance_After = toBN(await collateralToken.balanceOf(dennis))
     const receivedETH = dennis_ETHBalance_After.sub(dennis_ETHBalance_Before)
 
     const expectedTotalETHDrawn = redemptionAmount.div(toBN(200)) // convert redemptionAmount LUSD to ETH, at ETH:USD price 200
@@ -2565,7 +2558,6 @@ contract('TroveManager', async accounts => {
     assert.equal(dennis_LUSDBalance_After, dennis_LUSDBalance_Before.sub(redemptionAmount))
   })
 
-  //failing
   it('redeemCollateral(): with invalid first hint, trove below MCR', async () => {
     // --- SETUP ---
     const { totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(310, 16)), extraLUSDAmount: dec(10, 18), extraParams: { from: alice } })
@@ -2576,7 +2568,7 @@ contract('TroveManager', async accounts => {
     // start Dennis with a high ICR
     await openTrove({ ICR: toBN(dec(100, 18)), extraLUSDAmount: redemptionAmount, extraParams: { from: dennis } })
 
-    const dennis_ETHBalance_Before = toBN(await web3.eth.getBalance(dennis))
+    const dennis_ETHBalance_Before = toBN(await collateralToken.balanceOf(dennis))
 
     const dennis_LUSDBalance_Before = await lusdToken.balanceOf(dennis)
 
@@ -2619,7 +2611,6 @@ contract('TroveManager', async accounts => {
       0, th._100pct,
       {
         from: dennis,
-        gasPrice: 0
       }
     )
 
@@ -2640,7 +2631,7 @@ contract('TroveManager', async accounts => {
     assert.equal(bob_debt_After, '0')
     assert.equal(carol_debt_After, '0')
 
-    const dennis_ETHBalance_After = toBN(await web3.eth.getBalance(dennis))
+    const dennis_ETHBalance_After = toBN(await collateralToken.balanceOf(dennis))
     const receivedETH = dennis_ETHBalance_After.sub(dennis_ETHBalance_Before)
 
     const expectedTotalETHDrawn = redemptionAmount.div(toBN(200)) // convert redemptionAmount LUSD to ETH, at ETH:USD price 200
@@ -2819,7 +2810,6 @@ contract('TroveManager', async accounts => {
     await th.assertIsApproximatelyEqual(A_debt, dec(6000, 18))
   })
 
-  //failing
   it('redeemCollateral(): doesnt perform the final partial redemption in the sequence if the hint is out-of-date', async () => {
     // --- SETUP ---
     const { totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(363, 16)), extraLUSDAmount: dec(5, 18), extraParams: { from: alice } })
@@ -2832,7 +2822,7 @@ contract('TroveManager', async accounts => {
 
     await openTrove({ ICR: toBN(dec(100, 18)), extraLUSDAmount: redemptionAmount, extraParams: { from: dennis } })
 
-    const dennis_ETHBalance_Before = toBN(await web3.eth.getBalance(dennis))
+    const dennis_ETHBalance_Before = toBN(await collateralToken.balanceOf(dennis))
 
     const dennis_LUSDBalance_Before = await lusdToken.balanceOf(dennis)
 
@@ -2891,7 +2881,6 @@ contract('TroveManager', async accounts => {
       0, th._100pct,
       {
         from: dennis,
-        gasPrice: 0
       }
     )
 
@@ -2906,7 +2895,7 @@ contract('TroveManager', async accounts => {
     // got in the way, he would have needed to redeem 3 LUSD to fully complete his redemption of 20 LUSD.
     // This would have required a different hint, therefore he ended up with a partial redemption.
 
-    const dennis_ETHBalance_After = toBN(await web3.eth.getBalance(dennis))
+    const dennis_ETHBalance_After = toBN(await collateralToken.balanceOf(dennis))
     const receivedETH = dennis_ETHBalance_After.sub(dennis_ETHBalance_Before)
 
     // Expect only 17 worth of ETH drawn
@@ -4204,7 +4193,6 @@ contract('TroveManager', async accounts => {
     th.assertIsApproximatelyEqual(D_emittedColl, D_coll.sub(partialAmount.mul(mv._1e18BN).div(price)))
   })
 
-  //failing
   it("redeemCollateral(): a redemption that closes a trove leaves the trove's ETH surplus (collateral - ETH drawn) available for the trove owner to claim", async () => {
     const {
       A_netDebt, A_coll,
@@ -4219,9 +4207,9 @@ contract('TroveManager', async accounts => {
     // CollSurplusPool endpoint cannot be called directly
     await assertRevert(collSurplusPool.claimColl(A), 'CollSurplusPool: Caller is not Borrower Operations')
 
-    await borrowerOperations.claimCollateral({ from: A, gasPrice: 0 })
-    await borrowerOperations.claimCollateral({ from: B, gasPrice: 0 })
-    await borrowerOperations.claimCollateral({ from: C, gasPrice: 0 })
+    await borrowerOperations.claimCollateral({ from: A })
+    await borrowerOperations.claimCollateral({ from: B })
+    await borrowerOperations.claimCollateral({ from: C })
 
     const A_balanceAfter = toBN(await collateralToken.balanceOf(A))
     const B_balanceAfter = toBN(await collateralToken.balanceOf(B))
@@ -4234,8 +4222,7 @@ contract('TroveManager', async accounts => {
     th.assertIsApproximatelyEqual(C_balanceAfter, C_balanceBefore.add(C_coll.sub(C_netDebt.mul(mv._1e18BN).div(price))))
   })
 
-  //failing
-  it.only("redeemCollateral(): a redemption that closes a trove leaves the trove's ETH surplus (collateral - ETH drawn) available for the trove owner after re-opening trove", async () => {
+  it("redeemCollateral(): a redemption that closes a trove leaves the trove's ETH surplus (collateral - ETH drawn) available for the trove owner after re-opening trove", async () => {
     const {
       A_netDebt, A_coll: A_collBefore,
       B_netDebt, B_coll: B_collBefore,
@@ -4259,17 +4246,17 @@ contract('TroveManager', async accounts => {
     assert.isTrue(B_collAfter.eq(B_coll))
     assert.isTrue(C_collAfter.eq(C_coll))
 
-    const A_balanceBefore = toBN(await web3.eth.getBalance(A))
-    const B_balanceBefore = toBN(await web3.eth.getBalance(B))
-    const C_balanceBefore = toBN(await web3.eth.getBalance(C))
+    const A_balanceBefore = toBN(await collateralToken.balanceOf(A))
+    const B_balanceBefore = toBN(await collateralToken.balanceOf(B))
+    const C_balanceBefore = toBN(await collateralToken.balanceOf(C))
 
-    await borrowerOperations.claimCollateral({ from: A, gasPrice: 0 })
-    await borrowerOperations.claimCollateral({ from: B, gasPrice: 0 })
-    await borrowerOperations.claimCollateral({ from: C, gasPrice: 0 })
+    await borrowerOperations.claimCollateral({ from: A })
+    await borrowerOperations.claimCollateral({ from: B })
+    await borrowerOperations.claimCollateral({ from: C })
 
-    const A_balanceAfter = toBN(await web3.eth.getBalance(A))
-    const B_balanceAfter = toBN(await web3.eth.getBalance(B))
-    const C_balanceAfter = toBN(await web3.eth.getBalance(C))
+    const A_balanceAfter = toBN(await collateralToken.balanceOf(A))
+    const B_balanceAfter = toBN(await collateralToken.balanceOf(B))
+    const C_balanceAfter = toBN(await collateralToken.balanceOf(C))
 
     th.assertIsApproximatelyEqual(A_balanceAfter, A_balanceBefore.add(A_surplus))
     th.assertIsApproximatelyEqual(B_balanceAfter, B_balanceBefore.add(B_surplus))
@@ -4308,12 +4295,14 @@ contract('TroveManager', async accounts => {
         0, th._100pct,
         {
           from: alice,
-          gasPrice: 0
         }
       )
 
       await openTrove({ ICR: toBN(dec(150, 16)), extraParams: { from: bob } })
-      await borrowerOperations.adjustTrove(th._100pct, 0, lusdAmount, true, alice, alice, { from: alice, value: lusdAmount.mul(mv._1e18BN).div(price) })
+      await collateralToken.mint(alice, lusdAmount.mul(mv._1e18BN).div(price));
+      await collateralToken.approveInternal(alice, borrowerOperations.address, lusdAmount.mul(mv._1e18BN).div(price));
+      // TODO: fix adjustTrove
+      await borrowerOperations.adjustTrove(th._100pct, 0, lusdAmount, true, alice, alice, { from: alice })
     }
 
     const {
@@ -4331,7 +4320,6 @@ contract('TroveManager', async accounts => {
         0, th._100pct,
         {
           from: alice,
-          gasPrice: 0
         }
       ),
       'TroveManager: Fee would eat up all returned collateral'

--- a/packages/contracts/test/TroveManagerTest.js
+++ b/packages/contracts/test/TroveManagerTest.js
@@ -601,6 +601,7 @@ contract('TroveManager', async accounts => {
     assert.isTrue(TCR_5.gte(TCR_4))
   })
 
+  //failing
   it("liquidate(): a pure redistribution reduces the TCR only as a result of compensation", async () => {
     await openTrove({ ICR: toBN(dec(4, 18)), extraParams: { from: whale } })
 
@@ -837,6 +838,7 @@ contract('TroveManager', async accounts => {
     assert.isAtMost(th.getDifference(bob_ETHGain_After, bob_ETHGain_Before.add(th.applyLiquidationFee(B_collateral).mul(bob_Deposit_Before).div(totalDeposits))), 1000000)
   })
 
+  //failing
   it("liquidate(): does not alter the liquidated user's token balance", async () => {
     await openTrove({ ICR: toBN(dec(10, 18)), extraParams: { from: whale } })
     const { lusdAmount: A_lusdAmount } = await openTrove({ ICR: toBN(dec(2, 18)), extraLUSDAmount: toBN(dec(300, 18)), extraParams: { from: alice } })
@@ -879,6 +881,7 @@ contract('TroveManager', async accounts => {
     assert.equal((await lusdToken.balanceOf(carol)).toString(), C_lusdAmount)
   })
 
+  // failing
   it("liquidate(): liquidates based on entire/collateral debt (including pending rewards), not raw collateral/debt", async () => {
     await openTrove({ ICR: toBN(dec(8, 18)), extraLUSDAmount: toBN(dec(100, 18)), extraParams: { from: alice } })
     await openTrove({ ICR: toBN(dec(221, 16)), extraLUSDAmount: toBN(dec(100, 18)), extraParams: { from: bob } })
@@ -1038,7 +1041,7 @@ contract('TroveManager', async accounts => {
   })
 
   // --- liquidateTroves() ---
-
+  //failing
   it('liquidateTroves(): liquidates a Trove that a) was skipped in a previous liquidation and b) has pending rewards', async () => {
     // A, B, C, D, E open troves
     await openTrove({ ICR: toBN(dec(333, 16)), extraParams: { from: D } })
@@ -1284,7 +1287,7 @@ contract('TroveManager', async accounts => {
     assert.equal(listSize_Before, listSize_After)
   })
 
-  
+  //failing
   it("liquidateTroves(): liquidates based on entire/collateral debt (including pending rewards), not raw collateral/debt", async () => {
     await openTrove({ ICR: toBN(dec(400, 16)), extraParams: { from: alice } })
     await openTrove({ ICR: toBN(dec(221, 16)), extraParams: { from: bob } })
@@ -1601,6 +1604,7 @@ contract('TroveManager', async accounts => {
     assert.isTrue(TCR_After.gte(TCR_Before.mul(toBN(995)).div(toBN(1000))))
   })
 
+  //failing
   it("liquidateTroves(): Liquidating troves with SP deposits correctly impacts their SP deposit and ETH gain", async () => {
     // Whale provides 400 LUSD to the SP
     const whaleDeposit = toBN(dec(40000, 18))
@@ -1777,7 +1781,7 @@ contract('TroveManager', async accounts => {
 
 
   // --- batchLiquidateTroves() ---
-
+  //failing
   it('batchLiquidateTroves(): liquidates a Trove that a) was skipped in a previous liquidation and b) has pending rewards', async () => {
     // A, B, C, D, E open troves 
     await openTrove({ ICR: toBN(dec(300, 16)), extraParams: { from: C } })
@@ -2324,6 +2328,7 @@ contract('TroveManager', async accounts => {
     assert.equal(partialRedemptionHintNICR, '0')
   });
 
+  //failing
   it('redeemCollateral(): cancels the provided LUSD with debt from Troves with the lowest ICRs and sends an equivalent amount of Ether', async () => {
     // --- SETUP ---
     const { totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(310, 16)), extraLUSDAmount: dec(10, 18), extraParams: { from: alice } })
@@ -2404,6 +2409,7 @@ contract('TroveManager', async accounts => {
     assert.equal(dennis_LUSDBalance_After, dennis_LUSDBalance_Before.sub(redemptionAmount))
   })
 
+  //failing
   it('redeemCollateral(): with invalid first hint, zero address', async () => {
     // --- SETUP ---
     const { totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(310, 16)), extraLUSDAmount: dec(10, 18), extraParams: { from: alice } })
@@ -2484,6 +2490,7 @@ contract('TroveManager', async accounts => {
     assert.equal(dennis_LUSDBalance_After, dennis_LUSDBalance_Before.sub(redemptionAmount))
   })
 
+  //failing
   it('redeemCollateral(): with invalid first hint, non-existent trove', async () => {
     // --- SETUP ---
     const { totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(310, 16)), extraLUSDAmount: dec(10, 18), extraParams: { from: alice } })
@@ -2564,6 +2571,7 @@ contract('TroveManager', async accounts => {
     assert.equal(dennis_LUSDBalance_After, dennis_LUSDBalance_Before.sub(redemptionAmount))
   })
 
+  //failing
   it('redeemCollateral(): with invalid first hint, trove below MCR', async () => {
     // --- SETUP ---
     const { totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(310, 16)), extraLUSDAmount: dec(10, 18), extraParams: { from: alice } })
@@ -2752,6 +2760,7 @@ contract('TroveManager', async accounts => {
     assert.equal(carol_Status, 1)
   })
 
+  //failing
   it("redeemCollateral(): performs partial redemption if resultant debt is > minimum net debt", async () => {
     await borrowerOperations.openTrove(th._100pct, await getOpenTroveLUSDAmount(dec(10000, 18)), A, A, { from: A, value: dec(1000, 'ether') })
     await borrowerOperations.openTrove(th._100pct, await getOpenTroveLUSDAmount(dec(20000, 18)), B, B, { from: B, value: dec(1000, 'ether') })
@@ -2780,6 +2789,7 @@ contract('TroveManager', async accounts => {
     await th.assertIsApproximatelyEqual(A_debt, dec(4600, 18), 1000) 
   })
 
+  //failing
   it("redeemCollateral(): doesn't perform partial redemption if resultant debt would be < minimum net debt", async () => {
     await borrowerOperations.openTrove(th._100pct, await getOpenTroveLUSDAmount(dec(6000, 18)), A, A, { from: A, value: dec(1000, 'ether') })
     await borrowerOperations.openTrove(th._100pct, await getOpenTroveLUSDAmount(dec(20000, 18)), B, B, { from: B, value: dec(1000, 'ether') })
@@ -2809,6 +2819,7 @@ contract('TroveManager', async accounts => {
     await th.assertIsApproximatelyEqual(A_debt, dec(6000, 18))
   })
 
+  //failing
   it('redeemCollateral(): doesnt perform the final partial redemption in the sequence if the hint is out-of-date', async () => {
     // --- SETUP ---
     const { totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(363, 16)), extraLUSDAmount: dec(5, 18), extraParams: { from: alice } })
@@ -3205,6 +3216,7 @@ contract('TroveManager', async accounts => {
     assert.isTrue(tx5.receipt.status)
   })
 
+  //failing
   it("redeemCollateral(): doesn't affect the Stability Pool deposits or ETH gain of redeemed-from troves", async () => {
     await openTrove({ ICR: toBN(dec(20, 18)), extraParams: { from: whale } })
 
@@ -3825,6 +3837,7 @@ contract('TroveManager', async accounts => {
     assert.isTrue(lastFeeOpTime_3.gt(lastFeeOpTime_1))
   })
 
+  //failing
   it("redeemCollateral(): a redemption made at zero base rate send a non-zero ETHFee to LQTY staking contract", async () => {
     // time fast-forwards 1 year, and multisig stakes 1 LQTY
     await th.fastForwardTime(timeValues.SECONDS_IN_ONE_YEAR, web3.currentProvider)
@@ -3897,6 +3910,7 @@ contract('TroveManager', async accounts => {
     assert.isTrue(F_ETH_After.gt('0'))
   })
 
+  //failing
   it("redeemCollateral(): a redemption made at a non-zero base rate send a non-zero ETHFee to LQTY staking contract", async () => {
     // time fast-forwards 1 year, and multisig stakes 1 LQTY
     await th.fastForwardTime(timeValues.SECONDS_IN_ONE_YEAR, web3.currentProvider)
@@ -3982,6 +3996,7 @@ contract('TroveManager', async accounts => {
     assert.isTrue(F_ETH_After.gt(F_ETH_Before))
   })
 
+  //failing
   it("redeemCollateral(): a redemption sends the ETH remainder (ETHDrawn - ETHFee) to the redeemer", async () => {
     // time fast-forwards 1 year, and multisig stakes 1 LQTY
     await th.fastForwardTime(timeValues.SECONDS_IN_ONE_YEAR, web3.currentProvider)
@@ -4191,6 +4206,7 @@ contract('TroveManager', async accounts => {
     th.assertIsApproximatelyEqual(D_emittedColl, D_coll.sub(partialAmount.mul(mv._1e18BN).div(price)))
   })
 
+  //failing
   it("redeemCollateral(): a redemption that closes a trove leaves the trove's ETH surplus (collateral - ETH drawn) available for the trove owner to claim", async () => {
     const {
       A_netDebt, A_coll,
@@ -4220,6 +4236,7 @@ contract('TroveManager', async accounts => {
     th.assertIsApproximatelyEqual(C_balanceAfter, C_balanceBefore.add(C_coll.sub(C_netDebt.mul(mv._1e18BN).div(price))))
   })
 
+  //failing
   it("redeemCollateral(): a redemption that closes a trove leaves the trove's ETH surplus (collateral - ETH drawn) available for the trove owner after re-opening trove", async () => {
     const {
       A_netDebt, A_coll: A_collBefore,
@@ -4261,6 +4278,7 @@ contract('TroveManager', async accounts => {
     th.assertIsApproximatelyEqual(C_balanceAfter, C_balanceBefore.add(C_surplus))
   })
 
+  //failing
   it('redeemCollateral(): reverts if fee eats up all returned collateral', async () => {
     // --- SETUP ---
     const { lusdAmount } = await openTrove({ ICR: toBN(dec(200, 16)), extraLUSDAmount: dec(1, 24), extraParams: { from: alice } })


### PR DESCRIPTION
It seems like there was a lot of care done to keep track of the ETH
levels in the contracts and not just use the balances. I wonder if we
should keep that around.

