### PR TITLE
Create a price feed for gOHM

### DIFF
--- a/packages/contracts/contracts/Dependencies/IgOHM.sol
+++ b/packages/contracts/contracts/Dependencies/IgOHM.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.11;
+
+interface IgOHM {
+    /**
+        @notice converts gOHM amount to OHM
+        @param _amount uint
+        @return uint
+     */
+    function balanceFrom(uint256 _amount) external view returns (uint256);
+}

--- a/packages/contracts/contracts/Interfaces/IPriceFeed.sol
+++ b/packages/contracts/contracts/Interfaces/IPriceFeed.sol
@@ -4,9 +4,18 @@ pragma solidity 0.6.11;
 
 interface IPriceFeed {
 
+    enum Status {
+        chainlinkWorking, 
+        usingTellorChainlinkUntrusted, 
+        bothOraclesUntrusted,
+        usingTellorChainlinkFrozen, 
+        usingChainlinkTellorUntrusted
+    }
+
     // --- Events ---
     event LastGoodPriceUpdated(uint _lastGoodPrice);
    
     // --- Function ---
     function fetchPrice() external returns (uint);
+    function status() external returns (Status);
 }

--- a/packages/contracts/contracts/MultiPriceFeed.sol
+++ b/packages/contracts/contracts/MultiPriceFeed.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.11;
+
+import "./Interfaces/IPriceFeed.sol";
+import "./Dependencies/SafeMath.sol";
+import "./Dependencies/IgOHM.sol";
+import "./Dependencies/Ownable.sol";
+import "./Dependencies/CheckContract.sol";
+
+contract MultiPriceFeed is Ownable, CheckContract, IPriceFeed {
+    using SafeMath for uint256;
+
+    IPriceFeed public ethUSDFeed;
+    IPriceFeed public ohmETHFeed;
+    IgOHM public gOHM;
+    uint256 public lastPrice;
+
+    function setAddresses(
+        address _ethUSDFeedAddress,
+        address _ohmETHFeedAddress,
+        address _gOHMAddress
+    )
+        external
+        onlyOwner
+    {
+        checkContract(_ethUSDFeedAddress);
+        checkContract(_ohmETHFeedAddress);
+        checkContract(_gOHMAddress);
+
+        ethUSDFeed = IPriceFeed(_ethUSDFeedAddress);
+        ohmETHFeed = IPriceFeed(_ohmETHFeedAddress);
+        gOHM = IgOHM(_gOHMAddress);
+
+        _renounceOwnership();
+    }
+
+    function fetchPrice() external override returns (uint) {
+        uint256 ohmETHPrice = ohmETHFeed.fetchPrice();
+        uint256 ethUSDPrice = ethUSDFeed.fetchPrice();
+
+        require(ohmETHPrice > 0, "PriceFeed: OHM-ETH price is zero");
+        require(ethUSDPrice > 0, "PriceFeed: ETH-USD price is zero");
+
+        lastPrice = gOHM.balanceFrom(1e18).mul(ohmETHPrice).div(1e18).mul(ethUSDPrice).div(1e9);
+
+        return lastPrice;
+    }
+}

--- a/packages/contracts/contracts/MultiPriceFeed.sol
+++ b/packages/contracts/contracts/MultiPriceFeed.sol
@@ -7,14 +7,22 @@ import "./Dependencies/SafeMath.sol";
 import "./Dependencies/IgOHM.sol";
 import "./Dependencies/Ownable.sol";
 import "./Dependencies/CheckContract.sol";
-
+import "./Dependencies/console.sol";
 contract MultiPriceFeed is Ownable, CheckContract, IPriceFeed {
     using SafeMath for uint256;
 
     IPriceFeed public ethUSDFeed;
     IPriceFeed public ohmETHFeed;
     IgOHM public gOHM;
-    uint256 public lastPrice;
+
+    // The current status of the PricFeed,
+    IPriceFeed.Status public override status;
+
+    // The last good price computed from last good prices of the multiple price feeds
+    uint public lastGoodPrice;
+
+    event LastGoodPriceUpdated(uint _lastGoodPrice);
+    event PriceFeedStatusChanged(Status newStatus);
 
     function setAddresses(
         address _ethUSDFeedAddress,
@@ -35,15 +43,44 @@ contract MultiPriceFeed is Ownable, CheckContract, IPriceFeed {
         _renounceOwnership();
     }
 
-    function fetchPrice() external override returns (uint) {
+    function fetchPrice() external override returns (uint) {        
+        if (ohmETHFeed.status() == IPriceFeed.Status.bothOraclesUntrusted || 
+            ethUSDFeed.status() == IPriceFeed.Status.bothOraclesUntrusted) {        
+            _changeStatus(IPriceFeed.Status.bothOraclesUntrusted);
+            return lastGoodPrice;
+        }
+        if (ohmETHFeed.status() == IPriceFeed.Status.chainlinkWorking && 
+            ethUSDFeed.status() == IPriceFeed.Status.chainlinkWorking) {
+            //Happy path                      
+            _changeStatus(IPriceFeed.Status.chainlinkWorking);        
+        } else if (ohmETHFeed.status() == IPriceFeed.Status.usingTellorChainlinkFrozen ||
+            ethUSDFeed.status() == IPriceFeed.Status.usingTellorChainlinkFrozen) {            
+            _changeStatus(IPriceFeed.Status.usingTellorChainlinkFrozen);            
+        } else if (ohmETHFeed.status() == IPriceFeed.Status.usingTellorChainlinkUntrusted ||
+            ethUSDFeed.status() == IPriceFeed.Status.usingTellorChainlinkUntrusted) {
+            _changeStatus(IPriceFeed.Status.usingTellorChainlinkUntrusted);                    
+        } else if (ohmETHFeed.status() == IPriceFeed.Status.usingChainlinkTellorUntrusted ||
+            ethUSDFeed.status() == IPriceFeed.Status.usingChainlinkTellorUntrusted) {
+            _changeStatus(IPriceFeed.Status.usingChainlinkTellorUntrusted);            
+        }
+
         uint256 ohmETHPrice = ohmETHFeed.fetchPrice();
         uint256 ethUSDPrice = ethUSDFeed.fetchPrice();
 
         require(ohmETHPrice > 0, "PriceFeed: OHM-ETH price is zero");
         require(ethUSDPrice > 0, "PriceFeed: ETH-USD price is zero");
 
-        lastPrice = gOHM.balanceFrom(1e18).mul(ohmETHPrice).div(1e18).mul(ethUSDPrice).div(1e9);
+        lastGoodPrice = gOHM.balanceFrom(1e18).mul(ohmETHPrice).div(1e18).mul(ethUSDPrice).div(1e9);
 
-        return lastPrice;
+        return lastGoodPrice;
     }
+
+
+    function _changeStatus(Status _status) internal {        
+        if (status != _status){
+            status = _status;            
+            emit PriceFeedStatusChanged(_status);
+        }
+    }
+
 }

--- a/packages/contracts/contracts/MultiPriceFeed.sol
+++ b/packages/contracts/contracts/MultiPriceFeed.sol
@@ -7,7 +7,7 @@ import "./Dependencies/SafeMath.sol";
 import "./Dependencies/IgOHM.sol";
 import "./Dependencies/Ownable.sol";
 import "./Dependencies/CheckContract.sol";
-import "./Dependencies/console.sol";
+
 contract MultiPriceFeed is Ownable, CheckContract, IPriceFeed {
     using SafeMath for uint256;
 
@@ -21,8 +21,8 @@ contract MultiPriceFeed is Ownable, CheckContract, IPriceFeed {
     // The last good price computed from last good prices of the multiple price feeds
     uint public lastGoodPrice;
 
-    event LastGoodPriceUpdated(uint _lastGoodPrice);
-    event PriceFeedStatusChanged(Status newStatus);
+    event LastGoodMultiPriceUpdated(uint _lastGoodPrice);
+    event MultiPriceFeedStatusChanged(Status newStatus);
 
     function setAddresses(
         address _ethUSDFeedAddress,
@@ -71,6 +71,7 @@ contract MultiPriceFeed is Ownable, CheckContract, IPriceFeed {
         require(ethUSDPrice > 0, "PriceFeed: ETH-USD price is zero");
 
         lastGoodPrice = gOHM.balanceFrom(1e18).mul(ohmETHPrice).div(1e18).mul(ethUSDPrice).div(1e9);
+        emit LastGoodMultiPriceUpdated(lastGoodPrice);
 
         return lastGoodPrice;
     }
@@ -79,7 +80,7 @@ contract MultiPriceFeed is Ownable, CheckContract, IPriceFeed {
     function _changeStatus(Status _status) internal {        
         if (status != _status){
             status = _status;            
-            emit PriceFeedStatusChanged(_status);
+            emit MultiPriceFeedStatusChanged(_status);
         }
     }
 

--- a/packages/contracts/contracts/PriceFeed.sol
+++ b/packages/contracts/contracts/PriceFeed.sol
@@ -68,16 +68,8 @@ contract PriceFeed is Ownable, CheckContract, BaseMath, IPriceFeed {
         bool success;
     }
 
-    enum Status {
-        chainlinkWorking, 
-        usingTellorChainlinkUntrusted, 
-        bothOraclesUntrusted,
-        usingTellorChainlinkFrozen, 
-        usingChainlinkTellorUntrusted
-    }
-
     // The current status of the PricFeed, which determines the conditions for the next price fetch attempt
-    Status public status;
+    IPriceFeed.Status public override status;
 
     event LastGoodPriceUpdated(uint _lastGoodPrice);
     event PriceFeedStatusChanged(Status newStatus);

--- a/packages/contracts/contracts/TestContracts/PriceFeedTestnet.sol
+++ b/packages/contracts/contracts/TestContracts/PriceFeedTestnet.sol
@@ -10,6 +10,7 @@ import "../Interfaces/IPriceFeed.sol";
 */
 contract PriceFeedTestnet is IPriceFeed {
     
+    IPriceFeed.Status public override status;
     uint256 private _price = 200 * 1e18;
 
     // --- Functions ---
@@ -30,5 +31,9 @@ contract PriceFeedTestnet is IPriceFeed {
     function setPrice(uint256 price) external returns (bool) {
         _price = price;
         return true;
+    }    
+
+    function setStatus(Status _status) external {
+        status = _status;
     }
 }

--- a/packages/contracts/contracts/TestContracts/gOHMTester.sol
+++ b/packages/contracts/contracts/TestContracts/gOHMTester.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.11;
+
+import "../Dependencies/IgOHM.sol";
+import "../Dependencies/SafeMath.sol";
+
+contract gOHMTester is IgOHM {
+    using SafeMath for uint256;
+
+    uint256 immutable decimals = 18;
+    uint256 public index = 0;
+
+    function setIndex(uint256 _index) external {
+        index = _index;
+    }
+
+    /**
+        @notice converts gOHM amount to OHM
+        @param _amount uint
+        @return uint
+     */
+    function balanceFrom(uint256 _amount) public view override returns (uint256) {
+        return _amount.mul(index).div(10**decimals);
+    }
+}

--- a/packages/contracts/test/MultiPriceFeedTest.js
+++ b/packages/contracts/test/MultiPriceFeedTest.js
@@ -29,6 +29,9 @@ contract('PriceFeed', async accounts => {
         gOHM.address,
         { from: owner }
     );
+
+    await ethUSDFeed.setStatus(0);
+    await ohmETHFeed.setStatus(0);
   });
 
   it("returns the USD price with 18 decimals", async () => {
@@ -98,43 +101,87 @@ contract('PriceFeed', async accounts => {
   });
 
   it("bothOraclesUntrusted ", async () => {
+    await ethUSDFeed.setPrice(toBN('4100682166650000000000'));
+    await ohmETHFeed.setPrice(toBN('141193844780215400'));
+    await gOHM.setIndex(toBN('41428690506'));
+    await priceFeed.fetchPrice();
+    let price = await priceFeed.lastGoodPrice();      
+    assert.equal(`${price}`, '23986842311112663398400');
+    
+    await ethUSDFeed.setPrice(toBN('0'));  //This is key - ensure we pickup prior last good price
+    await ohmETHFeed.setPrice(toBN('0'));  //This is key - ensure we pickup prior last good price
     await ethUSDFeed.setStatus(2);
     await ohmETHFeed.setStatus(2);
     await priceFeed.fetchPrice();
     let status = await priceFeed.status();
     assert.equal(status, 2);
+
+    price = await priceFeed.lastGoodPrice();
+    assert.equal(`${price}`, '23986842311112663398400');
   });
 
   it("chainlinkWorking ", async () => {
+    await ethUSDFeed.setPrice(toBN('4100682166650000000000'));
+    await ohmETHFeed.setPrice(toBN('141193844780215400'));
+    await gOHM.setIndex(toBN('41428690506'));
+    
     await ethUSDFeed.setStatus(0);
     await ohmETHFeed.setStatus(0);         
     await priceFeed.fetchPrice();
     let status = await priceFeed.status();
     assert.equal(status, 0);
+
+    await priceFeed.fetchPrice();
+    let price = await priceFeed.lastGoodPrice();      
+    assert.equal(`${price}`, '23986842311112663398400');
   });
 
   it("usingTellorChainlinkUntrusted ", async () => {
+    await ethUSDFeed.setPrice(toBN('4100682166650000000000'));
+    await ohmETHFeed.setPrice(toBN('141193844780215400'));
+    await gOHM.setIndex(toBN('41428690506'));
+
     await ethUSDFeed.setStatus(1);
-    await ohmETHFeed.setStatus(0);         
+    await ohmETHFeed.setStatus(0);
+    
     await priceFeed.fetchPrice();
     let status = await priceFeed.status();
     assert.equal(status, 1);
+
+    price = await priceFeed.lastGoodPrice();
+    assert.equal(`${price}`, '23986842311112663398400');
   });
   
   it("usingTellorChainlinkFrozen ", async () => {
+    await ethUSDFeed.setPrice(toBN('4100682166650000000000'));
+    await ohmETHFeed.setPrice(toBN('141193844780215400'));
+    await gOHM.setIndex(toBN('41428690506'));
+
     await ethUSDFeed.setStatus(3);
-    await ohmETHFeed.setStatus(0);         
+    await ohmETHFeed.setStatus(0);
+    
     await priceFeed.fetchPrice();
+  
     let status = await priceFeed.status();
     assert.equal(status, 3);
+    price = await priceFeed.lastGoodPrice();
+    assert.equal(`${price}`, '23986842311112663398400');
   });    
 
   it("usingChainlinkTellorUntrusted ", async () => {
+    await ethUSDFeed.setPrice(toBN('4100682166650000000000'));
+    await ohmETHFeed.setPrice(toBN('141193844780215400'));
+    await gOHM.setIndex(toBN('41428690506'));
+
     await ethUSDFeed.setStatus(4);
-    await ohmETHFeed.setStatus(0);         
+    await ohmETHFeed.setStatus(0);
+    
     await priceFeed.fetchPrice();
+    
     let status = await priceFeed.status();
     assert.equal(status, 4);
+    price = await priceFeed.lastGoodPrice();
+    assert.equal(`${price}`, '23986842311112663398400');    
   });    
 
 });

--- a/packages/contracts/test/MultiPriceFeedTest.js
+++ b/packages/contracts/test/MultiPriceFeedTest.js
@@ -1,0 +1,69 @@
+const MultiPriceFeed = artifacts.require("./MultiPriceFeed.sol")
+const PriceFeedTestnet = artifacts.require("./PriceFeedTestnet.sol")
+const gOHMTester = artifacts.require("./gOHMTester.sol")
+
+const testHelpers = require("../utils/testHelpers.js")
+const {dec, toBN} = testHelpers.TestHelper;
+
+contract('PriceFeed', async accounts => {
+  const [owner] = accounts;
+  let ohmETHFeed;
+  let ethUSDFeed;
+  let gOHM;
+  let priceFeed
+
+  beforeEach(async () => {
+    priceFeed = await MultiPriceFeed.new();
+    MultiPriceFeed.setAsDeployed(priceFeed);
+    ohmETHFeed = await PriceFeedTestnet.new();
+    ethUSDFeed = await PriceFeedTestnet.new();
+    PriceFeedTestnet.setAsDeployed(ohmETHFeed);
+    PriceFeedTestnet.setAsDeployed(ethUSDFeed);
+    
+    gOHM = await gOHMTester.new();
+    gOHMTester.setAsDeployed(gOHM);
+
+    await priceFeed.setAddresses(
+        ethUSDFeed.address,
+        ohmETHFeed.address,
+        gOHM.address,
+        { from: owner }
+    );
+  });
+
+  it("returns the USD price with 18 decimals", async () => {
+      await ethUSDFeed.setPrice(toBN('4100682166650000000000'));
+      await ohmETHFeed.setPrice(toBN('141193844780215400'));
+      await gOHM.setIndex(toBN('41428690506'));
+      await priceFeed.fetchPrice();
+      let price = await priceFeed.lastPrice();
+      // $23,986.84
+      assert.equal(`${price}`, '23986842311112663398400');
+  });
+
+  it("reverts if the ETH-USD price is zero", async () => {
+      await ethUSDFeed.setPrice(toBN('0'));
+      await ohmETHFeed.setPrice(toBN('141193844780215400'));
+      await gOHM.setIndex(toBN('41428690506'));
+      try {
+        await priceFeed.fetchPrice();
+        assert.isTrue(false);
+      } catch (err) {
+        assert.include(err.message, "revert");
+        assert.include(err.message, "ETH-USD");
+      }
+  });
+
+  it("reverts if the OHM-ETH price is zero", async () => {
+      await ethUSDFeed.setPrice(toBN('4100682166650000000000'));
+      await ohmETHFeed.setPrice(toBN('0'));
+      await gOHM.setIndex(toBN('41428690506'));
+      try {
+        await priceFeed.fetchPrice();
+        assert.isTrue(false);
+      } catch (err) {
+        assert.include(err.message, "revert");
+        assert.include(err.message, "OHM-ETH");
+      }
+  });
+});

--- a/packages/contracts/test/MultiPriceFeedTest.js
+++ b/packages/contracts/test/MultiPriceFeedTest.js
@@ -36,7 +36,7 @@ contract('PriceFeed', async accounts => {
       await ohmETHFeed.setPrice(toBN('141193844780215400'));
       await gOHM.setIndex(toBN('41428690506'));
       await priceFeed.fetchPrice();
-      let price = await priceFeed.lastPrice();
+      let price = await priceFeed.lastGoodPrice();
       // $23,986.84
       assert.equal(`${price}`, '23986842311112663398400');
   });
@@ -46,7 +46,7 @@ contract('PriceFeed', async accounts => {
       await ohmETHFeed.setPrice(toBN('141193844780215400'));
       await gOHM.setIndex(dec(10000, 9));
       await priceFeed.fetchPrice();
-      let price = await priceFeed.lastPrice();
+      let price = await priceFeed.lastGoodPrice();
       // $5,789,910.81
       assert.equal(`${price}`, '5789910813309143290203300');
   });
@@ -56,7 +56,7 @@ contract('PriceFeed', async accounts => {
       await ohmETHFeed.setPrice(toBN('141193844780215400'));
       await gOHM.setIndex(toBN('41428690506'));
       await priceFeed.fetchPrice();
-      let price = await priceFeed.lastPrice();
+      let price = await priceFeed.lastGoodPrice();
       // $239,868,423.11
       assert.equal(`${price}`, '239868423111126633984000000');
   });
@@ -66,7 +66,7 @@ contract('PriceFeed', async accounts => {
       await ohmETHFeed.setPrice(toBN('1411938447802154000000'));
       await gOHM.setIndex(toBN('41428690506'));
       await priceFeed.fetchPrice();
-      let price = await priceFeed.lastPrice();
+      let price = await priceFeed.lastGoodPrice();
       // $239,868,423.14
       assert.equal(`${price}`, '239868423141951461830708050');
   });
@@ -96,4 +96,45 @@ contract('PriceFeed', async accounts => {
         assert.include(err.message, "OHM-ETH");
       }
   });
+
+  it("bothOraclesUntrusted ", async () => {
+    await ethUSDFeed.setStatus(2);
+    await ohmETHFeed.setStatus(2);
+    await priceFeed.fetchPrice();
+    let status = await priceFeed.status();
+    assert.equal(status, 2);
+  });
+
+  it("chainlinkWorking ", async () => {
+    await ethUSDFeed.setStatus(0);
+    await ohmETHFeed.setStatus(0);         
+    await priceFeed.fetchPrice();
+    let status = await priceFeed.status();
+    assert.equal(status, 0);
+  });
+
+  it("usingTellorChainlinkUntrusted ", async () => {
+    await ethUSDFeed.setStatus(1);
+    await ohmETHFeed.setStatus(0);         
+    await priceFeed.fetchPrice();
+    let status = await priceFeed.status();
+    assert.equal(status, 1);
+  });
+  
+  it("usingTellorChainlinkFrozen ", async () => {
+    await ethUSDFeed.setStatus(3);
+    await ohmETHFeed.setStatus(0);         
+    await priceFeed.fetchPrice();
+    let status = await priceFeed.status();
+    assert.equal(status, 3);
+  });    
+
+  it("usingChainlinkTellorUntrusted ", async () => {
+    await ethUSDFeed.setStatus(4);
+    await ohmETHFeed.setStatus(0);         
+    await priceFeed.fetchPrice();
+    let status = await priceFeed.status();
+    assert.equal(status, 4);
+  });    
+
 });

--- a/packages/contracts/test/MultiPriceFeedTest.js
+++ b/packages/contracts/test/MultiPriceFeedTest.js
@@ -41,6 +41,36 @@ contract('PriceFeed', async accounts => {
       assert.equal(`${price}`, '23986842311112663398400');
   });
 
+  it("avoids rounding errors when index is large", async () => {
+      await ethUSDFeed.setPrice(toBN('4100682166650000000000'));
+      await ohmETHFeed.setPrice(toBN('141193844780215400'));
+      await gOHM.setIndex(dec(10000, 9));
+      await priceFeed.fetchPrice();
+      let price = await priceFeed.lastPrice();
+      // $5,789,910.81
+      assert.equal(`${price}`, '5789910813309143290203300');
+  });
+
+  it("minimizes rounding errors when eth price is large", async () => {
+      await ethUSDFeed.setPrice(toBN('41006821666500000000000000'));
+      await ohmETHFeed.setPrice(toBN('141193844780215400'));
+      await gOHM.setIndex(toBN('41428690506'));
+      await priceFeed.fetchPrice();
+      let price = await priceFeed.lastPrice();
+      // $239,868,423.11
+      assert.equal(`${price}`, '239868423111126633984000000');
+  });
+
+  it("minimizes rounding errors when OHM price is large", async () => {
+      await ethUSDFeed.setPrice(toBN('4100682166650000000000'));
+      await ohmETHFeed.setPrice(toBN('1411938447802154000000'));
+      await gOHM.setIndex(toBN('41428690506'));
+      await priceFeed.fetchPrice();
+      let price = await priceFeed.lastPrice();
+      // $239,868,423.14
+      assert.equal(`${price}`, '239868423141951461830708050');
+  });
+
   it("reverts if the ETH-USD price is zero", async () => {
       await ethUSDFeed.setPrice(toBN('0'));
       await ohmETHFeed.setPrice(toBN('141193844780215400'));


### PR DESCRIPTION
This combines two price feeds the ETH-USD feed and a OHM-ETH feed that
is currently supported by Chainlink. This allows us to reuse all the
existing smarts for detecting bad oracles and falling back to Tellor.