### PR TITLE
Adds a debt limit configuration to the ActivePool

### DIFF
--- a/packages/contracts/contracts/Interfaces/IActivePool.sol
+++ b/packages/contracts/contracts/Interfaces/IActivePool.sol
@@ -11,7 +11,9 @@ interface IActivePool is IPool {
     event TroveManagerAddressChanged(address _newTroveManagerAddress);
     event ActivePoolDebtUpdated(uint _Debt);
     event ActivePoolCollateralUpdated(uint _Collateral);
+    event DebtLimitChanged(uint256 _debtLimit);
 
     // --- Functions ---
     function sendCollateral(address _account, uint _amount) external;
+    function getDebtLimit() external view returns (uint);
 }

--- a/packages/contracts/test/ActivePoolTest.js
+++ b/packages/contracts/test/ActivePoolTest.js
@@ -1,0 +1,118 @@
+const { artifacts } = require("hardhat")
+const deploymentHelper = require("../utils/deploymentHelpers.js")
+const testHelpers = require("../utils/testHelpers.js")
+const NonPayable = artifacts.require('NonPayable.sol')
+
+const th = testHelpers.TestHelper
+const dec = th.dec
+const toBN = th.toBN
+const mv = testHelpers.MoneyValues
+const timeValues = testHelpers.TimeValues
+
+const TroveManagerTester = artifacts.require("TroveManagerTester")
+const DebtToken = artifacts.require("DebtToken")
+const ERC20Mock = artifacts.require("./ERC20Mock.sol")
+
+
+
+contract('ActivePool', async accounts => {
+  const [
+    owner,
+    A, B, C, D, E] = accounts;
+
+  const [bountyAddress, lpRewardsAddress, multisig] = accounts.slice(997, 1000)
+
+  let borrowerOperations
+  let priceFeed
+  let activePool;
+
+  let contracts
+
+  async function openTroveHelper(account, collAmount, debtAmount) {
+      await collateralToken.mint(account, collAmount);
+      await collateralToken.approveInternal(account, borrowerOperations.address, collAmount);
+      await borrowerOperations.openTrove(collAmount, th._100pct, debtAmount, th.ZERO_ADDRESS, th.ZERO_ADDRESS, { from: account })
+  }
+
+  beforeEach(async () => {
+    collateralToken = await ERC20Mock.new("Test Collateral Token", "TEST", owner, 0);
+    ERC20Mock.setAsDeployed(collateralToken)
+
+    contracts = await deploymentHelper.deployLiquityCore(collateralToken)
+    contracts.troveManager = await TroveManagerTester.new()
+    contracts.debtToken = await DebtToken.new(
+      contracts.troveManager.address,
+      contracts.stabilityPool.address,
+      contracts.borrowerOperations.address
+    )
+    const LQTYContracts = await deploymentHelper.deployLQTYContracts(bountyAddress, lpRewardsAddress, multisig)
+
+    priceFeed = contracts.priceFeedTestnet
+    collSurplusPool = contracts.collSurplusPool
+    borrowerOperations = contracts.borrowerOperations
+    activePool = contracts.activePool
+
+    await deploymentHelper.connectCoreContracts(contracts, LQTYContracts)
+    await deploymentHelper.connectLQTYContracts(LQTYContracts)
+    await deploymentHelper.connectLQTYContractsToCore(LQTYContracts, contracts)
+  })
+
+  describe("debt limit", () => {
+      beforeEach(async () => {
+        await activePool.setDebtLimit(0);
+      });
+
+      it("can raise debt limit", async () => {
+        const initialLimit = await activePool.getDebtLimit();
+        assert.equal(initialLimit, 0);
+        await activePool.setDebtLimit(dec(100, 18));
+        let updated = await activePool.getDebtLimit();
+        assert.equal(updated, dec(100, 18));
+      });
+
+      it("can lower the debt limit", async () => {
+        const initialLimit = await activePool.getDebtLimit();
+        assert.equal(initialLimit, 0);
+        await activePool.setDebtLimit(dec(1000000, 18));
+        let updated = await activePool.getDebtLimit();
+        assert.equal(updated, dec(1000000, 18));
+        await activePool.setDebtLimit(dec(100, 18));
+        updated = await activePool.getDebtLimit();
+        assert.equal(updated, dec(100, 18));
+      })
+
+      it("can enforce the debt limit", async () => {
+        // debt limit set to borrow amount 10,000 + 200 gas comp + 50 fees
+        await activePool.setDebtLimit(dec(10250, 18));
+        let updated = await activePool.getDebtLimit();
+        assert.equal(updated, dec(10250, 18));
+        await openTroveHelper(A, dec(100000, 18), dec(10000, 18));
+        try {
+            await openTroveHelper(B, dec(100000, 18), dec(10000, 18));
+            assert.isTrue(false);
+        } catch (err) {
+            assert.include(err.message, "revert");
+            assert.include(err.message, "ActivePool: Cannot exceed debt limit");
+        }
+      })
+
+      it("can lower the debt limit to the current debt", async () => {
+        await contracts.activePool.setDebtLimit("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        await openTroveHelper(A, dec(100000, 18), dec(10000, 18));
+        // debt limit set to borrow amount 10,000 + 200 gas comp + 50 fees
+        await activePool.setDebtLimit(dec(10250, 18));
+        let updated = await activePool.getDebtLimit();
+        assert.equal(updated, dec(10250, 18));
+      })
+
+      it("will revert if attempting to lower debt limit below current amount", async () => {
+        await contracts.activePool.setDebtLimit("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        await openTroveHelper(A, dec(100000, 18), dec(10000, 18));
+        // debt limit set to borrow amount 10,000 + 200 gas comp + 50 fees
+        await th.assertRevert(activePool.setDebtLimit(dec(10249, 18)), "");
+      });
+  });
+})
+
+contract('Reset chain state', async accounts => { })
+

--- a/packages/contracts/test/OwnershipTest.js
+++ b/packages/contracts/test/OwnershipTest.js
@@ -62,7 +62,7 @@ contract('All Liquity functions with onlyOwner modifier', async accounts => {
     }
   }
 
-  const testSetAddresses = async (contract, numberOfAddresses) => {
+  const testSetAddresses = async (contract, numberOfAddresses, renounceable) => {
     const dumbContract = await GasPool.new()
     const params = Array(numberOfAddresses).fill(dumbContract.address)
 
@@ -78,6 +78,10 @@ contract('All Liquity functions with onlyOwner modifier', async accounts => {
     const txOwner = await contract.setAddresses(...params, { from: owner })
     assert.isTrue(txOwner.receipt.status)
     // fails if called twice
+    if (renounceable) {
+      await contract.renounceOwnership();
+    }
+
     await th.assertRevert(contract.setAddresses(...params, { from: owner }))
   }
 
@@ -107,7 +111,7 @@ contract('All Liquity functions with onlyOwner modifier', async accounts => {
 
   describe('ActivePool', async accounts => {
     it("setAddresses(): reverts when called by non-owner, with wrong addresses, or twice", async () => {
-      await testSetAddresses(activePool, 5)
+      await testSetAddresses(activePool, 5, true)
     })
   })
 

--- a/packages/contracts/test/PoolsTest.js
+++ b/packages/contracts/test/PoolsTest.js
@@ -65,6 +65,7 @@ contract('ActivePool', async accounts => {
     const recordedLUSD_balanceBefore = await activePool.getDebt()
     assert.equal(recordedLUSD_balanceBefore, 0)
 
+    await activePool.setDebtLimit(100);
     // await activePool.increaseDebt(100, { from: mockBorrowerOperationsAddress })
     const increaseDebtData = th.getTransactionData('increaseDebt(uint256)', ['0x64'])
     const tx = await mockBorrowerOperations.forward(activePool.address, increaseDebtData)
@@ -76,6 +77,7 @@ contract('ActivePool', async accounts => {
   it('decreaseLUSD(): decreases the recorded LUSD balance by the correct amount', async () => {
     // start the pool on 100 wei
     //await activePool.increaseDebt(100, { from: mockBorrowerOperationsAddress })
+    await activePool.setDebtLimit('0x64');
     const increaseDebtData = th.getTransactionData('increaseDebt(uint256)', ['0x64'])
     const tx1 = await mockBorrowerOperations.forward(activePool.address, increaseDebtData)
     assert.isTrue(tx1.receipt.status)

--- a/packages/contracts/utils/deploymentHelpers.js
+++ b/packages/contracts/utils/deploymentHelpers.js
@@ -393,6 +393,7 @@ class DeploymentHelper {
       contracts.defaultPool.address,
       contracts.collateralToken.address
     )
+    await contracts.activePool.setDebtLimit("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 
     await contracts.defaultPool.setAddresses(
       contracts.troveManager.address,


### PR DESCRIPTION
This will allow us to slowly ramp up the amount of debt in the system.
It requires delaying the renouncing of ownership of the ActivePool. Once
we uncap the debt, we can renounce the ownership and be fully immutable.